### PR TITLE
Ability to silence exceptions when building

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -45,11 +45,14 @@ $data = [
     ['nodeId' => 3, 'parentId' => -1, 'title' => 'Node 3'],
     ['nodeId' => 4, 'parentId' => 1, 'title' => 'Node 1.2'],
 ];
+$options = ['rootId' => -1, 'id' => 'nodeId', 'parent' => 'parentId'];
 $tree = new BlueM\Tree(
     $data,
-    ['rootId' => -1, 'id' => 'nodeId', 'parent' => 'parentId']
+    $options
 );
 ```
+
+By default, exceptions will be thrown if a node has a parent that doesn't exist, or a node references itself as it's parent. If you want to silece these exceptions and build the tree without them, simply pass `'silence' => true` in the options array.
 
 Updating the tree with new data
 -------------------------------

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,9 @@
         "ext-json": "*"
     },
     "autoload": {
-        "psr-4": {"BlueM\\": "src/"}
+        "psr-4": {
+            "BlueM\\": "src/"
+        }
     },
     "require-dev": {
         "phpunit/phpunit": "6.*",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/autoload.php">
+<phpunit>
     <testsuites>
         <testsuite name="TreeTest">
             <directory suffix="Test.php">./tests</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit>
+<phpunit bootstrap="./vendor/autoload.php">
     <testsuites>
         <testsuite name="TreeTest">
             <directory suffix="Test.php">./tests</directory>

--- a/tests/TreeTest.php
+++ b/tests/TreeTest.php
@@ -437,6 +437,26 @@ EXPECTED;
     }
 
     /**
+     * @test
+     */
+    public function familyErrorsCanBeSilencedWhenBuilding()
+    {
+        $tree = new Tree(
+            [
+                ['id' => 1, 'parent' => 0],
+                ['id' => 2, 'parent' => 1],
+                ['id' => 3, 'parent' => 4],
+                ['id' => 4, 'parent' => 4],
+            ],
+            [
+                'silence' => true
+            ]
+        );
+
+        static::assertSame('[{"id":1,"parent":0},{"id":2,"parent":1}]', json_encode($tree));
+    }
+
+    /**
      * @param bool $sorted
      *
      * @return array


### PR DESCRIPTION
fixes #22 

Basically, it isn't a huge deal if nodes reference themselves, or nodes' parents don't exist. So, this allows the user to silence for troublesome family members.